### PR TITLE
update name of liquibase changelog in properties

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,7 @@ spring:
 liquibase:
   url: jdbc:postgresql://localhost:5432/postgres?currentSchema=gateway
   default-schema: gateway
+  change-log: classpath:db/changelog/db.changelog-master.yml
   user: postgres
   password: postgres
 


### PR DESCRIPTION
After names of all yml files were made consistent liquibase started failing as change-log file name was no longer set to the default expected by liquibase.
If liquibase has already been ran previously in the environment, then the databasechangelog table will also need to be updated to the name of the updated file.